### PR TITLE
Patch existing documents imported from zotero if they already exist.

### DIFF
--- a/importData.mjs
+++ b/importData.mjs
@@ -180,7 +180,10 @@ async function fetchAllCitations() {
         const batch = deduped.slice(processed, processed + BATCH_SIZE - 1);
         const transaction = client.transaction();
         batch.forEach((document) => {
-          transaction.createIfNotExists(document);
+          transaction.createIfNotExists(document).patch(document._id, (p) => {
+            p.set(document);
+            return p;
+          });
         });
         console.log(
           `Committing batch ${processed + 1} through ${


### PR DESCRIPTION
Fixes #43 

This (hopefully) more intelligently merges changes from Zotero for documents that already exist. See #43 for details.

To test (**using the `development` dataset!**):
* Run sanity studio locally (`cd studio; npm run start`) and take a look at http://localhost:3333/desk/citation;2GJIAUUZ, note the empty date.
* In another terminal, run the import script (`npm run import:citations`) and wait for it to complete.
* Refresh the studio in your browser, and note that the date is now populated.