### PR TITLE
Fix quick start guide fetch & citations sort on the homepage

### DIFF
--- a/src/components/FancyGuide.js
+++ b/src/components/FancyGuide.js
@@ -37,7 +37,7 @@ const FancyGuide = ({ guide, onClick = () => {} }) => {
 
   return (
     <Card
-      key={guide.__metadata.id}
+      key={guide._id}
       variant="outlined"
       className={`${classes.card} ${classes.guide}`}
     >

--- a/src/components/SectionCitations.js
+++ b/src/components/SectionCitations.js
@@ -12,7 +12,7 @@ import Typography from "@mui/material/Typography";
 import client from "../utils/sanityClient";
 
 const query =
-  '*[_type == "citation"]{_id, citation, citationPublication, citationTitle, date, publicationTitle, ref, title, url, websiteTitle}[0...5] | order(date desc)';
+  '*[_type == "citation"]{_id, citation, citationPublication, citationTitle, date, publicationTitle, ref, title, url, websiteTitle} | order(date desc)';
 
 const useStyles = makeStyles((theme) => ({
   citation: {
@@ -60,7 +60,7 @@ const SectionCitations = () => {
       cites.forEach(citation => {
         allCitations = [...allCitations, citation];
       });
-      setCitations(allCitations);
+      setCitations(allCitations.slice(0,5));
     });
   }, []);
 

--- a/src/components/SectionGuides.js
+++ b/src/components/SectionGuides.js
@@ -15,29 +15,46 @@ import Typography from "@mui/material/Typography";
 // components
 import FancyGuide from "./FancyGuide";
 
+import client from "../utils/sanityClient";
+
+const query =
+  '*[_type == "guide"]{_id, title, slug, subtitle, _created_at, _updatedAt } | order(date desc)';
+
 const useStyles = makeStyles(() => ({
   em: {
     fontStyle: "italic",
-    textAlign: "center"
+    textAlign: "center",
   },
   title: {
-    textAlign: "center"
-  }
+    textAlign: "center",
+  },
 }));
 
-const SectionGuides = props => {
+const SectionGuides = () => {
   const classes = useStyles();
-  const { guides } = props;
+  const [guides, setGuides] = useState([]);
+
+  useEffect(() => {
+    client.fetch(query).then((gs) => {
+      let allGuides = [];
+      gs.forEach((g) => {
+        allGuides = [...allGuides, g];
+      });
+      setGuides(allGuides);
+    });
+  }, []);
+
+  useEffect(() => {}, [guides]);
 
   const sliderSettings = {
     dots: false,
     infinite: false,
     speed: 500,
     slidesToShow: 4,
-    slidesToScroll: 1
+    slidesToScroll: 1,
   };
 
-  const guideClick = url => {
+  const guideClick = (url) => {
     Router.push({ pathname: "/guide/" + url });
   };
 
@@ -60,11 +77,11 @@ const SectionGuides = props => {
           {guides && guides.length ? (
             <Box mt={4}>
               <Slider {...sliderSettings}>
-                {guides.map(guide => (
+                {guides.map((guide) => (
                   <FancyGuide
-                    key={guide.__metadata.id}
+                    key={guide.title}
                     guide={guide}
-                    onClick={() => guideClick(guide.slug)}
+                    onClick={() => guideClick(guide.slug.current)}
                   />
                 ))}
               </Slider>
@@ -77,7 +94,7 @@ const SectionGuides = props => {
 };
 
 SectionGuides.propTypes = {
-  guides: PropTypes.array
+  guides: PropTypes.array,
 };
 
 export default SectionGuides;

--- a/src/layouts/advanced.js
+++ b/src/layouts/advanced.js
@@ -50,7 +50,7 @@ function Advanced(props) {
               <SectionCitations />
             </Grid>
             <Grid item xs={12}>
-              <SectionGuides {...props} />
+              <SectionGuides />
             </Grid>
           </Grid>
         ) : (


### PR DESCRIPTION
This PR does two things:
- Fixes #41: A huge refactor had removed removed the props that seeded the quick start guides to the `SectionGuides` component. To fix this, I added the client fetch in that component. Run `npm run dev` locally and you should see the `SectionGuides` component on the homepage populated by whatever quick start guides you have in your local dev database 
- Partially fixes #44: The client fetch on the `SectionCitations` component was not sorting citations properly. With this fix, that component on the homepage should display the 5 most recently published citations in your local database  