### PR TITLE
Fix filtering in the tracker

### DIFF
--- a/src/components/SectionTracker.js
+++ b/src/components/SectionTracker.js
@@ -167,7 +167,7 @@ function SectionTracker(props) {
   }, [topics, query]);
 
   useEffect(() => {
-    console.log("this is the useEffect watching for Filters");
+
     if (allActions.length) {
       let newActions = allActions;
       if (filters.length) {

--- a/src/components/SectionTracker.js
+++ b/src/components/SectionTracker.js
@@ -132,8 +132,8 @@ function SectionTracker(props) {
     };
     if (Array.isArray(topics) && topics.length) {
       topics.map(topic => {
-        if (topic.type && topic.slug) {
-          newTopics[topic.type] && newTopics[topic.type].set(topic.slug, topic);
+        if (topic.type && topic.slug && topic.slug.current) {
+          newTopics[topic.type] && newTopics[topic.type].set(topic.slug.current, topic);
         }
       });
     }
@@ -172,6 +172,7 @@ function SectionTracker(props) {
             action.relatedTopics.length
           ) {
             action.relatedTopics.forEach(topic => {
+              console.log("FILTERS", filters)
               if (filters.findIndex(f => f.slug === topic.slug) >= 0)
                 matches += 1;
             });
@@ -182,7 +183,7 @@ function SectionTracker(props) {
         setActions(allPolicies);
       }
     }
-  }, [actions, filters]);
+  }, [filters]);
 
   const handleClose = topic => {
     if (topic && filters.findIndex(f => f.slug === topic.slug) < 0) {
@@ -429,9 +430,9 @@ function SectionTracker(props) {
                 onClose={handleCloseCompanies()}
               >
                 {companies && companies.length
-                  ? companies.map(company => (
+                  ? companies.map((company, idx) => (
                       <MenuItem
-                        key={companies.slug}
+                        key={companies.slug && companies.slug.current ? companies.slug.current : idx}
                         onClick={handleCloseCompanies(company)}
                         disableRipple
                       >
@@ -448,7 +449,7 @@ function SectionTracker(props) {
         <Grid container spacing={2} justifyContent="flex-start">
           {filters.length
             ? filters.map(filter => (
-                <Grid key={filter.__metadata.id} item>
+                <Grid key={filter.__metadata ? filter.__metadata.id : filter.id} item>
                   <Chip
                     label={filter.displayTitle || filter.name}
                     color={filter.type}
@@ -481,7 +482,7 @@ function SectionTracker(props) {
                       hover
                       role="checkbox"
                       tabIndex={-1}
-                      key={row.slug}
+                      key={typeof row.slug === 'object' ? row.slug.current : row.slug}
                     >
                       {headers.map(column => {
                         let value = row[column.id];
@@ -506,7 +507,7 @@ function SectionTracker(props) {
                             ) : column.id == "title" ? (
                               <Link
                                 className={classes.tableLink}
-                                href={row.slug}
+                                href={typeof row.slug === 'object' ? row.slug.current : row.slug}
                               >
                                 {value}
                               </Link>

--- a/src/components/SectionTracker.js
+++ b/src/components/SectionTracker.js
@@ -113,6 +113,7 @@ function SectionTracker(props) {
   useEffect(() => {
     client.fetch(policyActionsQuery).then((allPolicies) => {
       if (Array.isArray(allPolicies) && allPolicies.length) {
+        setActions(allPolicies);
         setAllActions(allPolicies);
       }
       setLoading(false);
@@ -168,10 +169,11 @@ function SectionTracker(props) {
   }, [topics, query]);
 
   useEffect(() => {
+    console.log("this is the useEffect watching for Filters");
     if (allActions.length) {
       let newActions = allActions;
       if (filters.length) {
-        newActions = allActions.filter((action) => {
+        newActions = newActions.filter((action) => {
           let matches = 0;
           if (
             Array.isArray(action.relatedTopics) &&
@@ -179,14 +181,13 @@ function SectionTracker(props) {
           ) {
             action.relatedTopics.forEach((topic) => {
               if (filters.findIndex((f) => f._key === topic._key) >= 0)
-              console.log("ITS A MATCH!!!!!!!")
               matches += 1;
             });
           }
           return matches >= filters.length;
         });
-        setActions(newActions);
       }
+      setActions(newActions);
     }
   }, [filters, allActions]);
 
@@ -476,7 +477,7 @@ function SectionTracker(props) {
               </TableRow>
             </TableHead>
             <TableBody>
-              {allActions
+              {actions
                 .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
                 .map((row) => {
                   return (
@@ -537,7 +538,7 @@ function SectionTracker(props) {
         <TablePagination
           rowsPerPageOptions={[10, 25, 100]}
           component="div"
-          count={allActions.length}
+          count={actions.length}
           rowsPerPage={rowsPerPage}
           page={page}
           onPageChange={handleChangePage}

--- a/src/components/SectionTracker.js
+++ b/src/components/SectionTracker.js
@@ -30,7 +30,7 @@ import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import KeyboardArrowRightIcon from "@mui/icons-material/KeyboardArrowRight";
 import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
 
-const policyActionsQuery = `*[_type == "policy_action"]{category, country->{_key,     displayTitle, name, slug}, dateInitiated, 
+const policyActionsQuery = `*[_type == "policy_action"]{category, country->{_key, displayTitle, name, slug}, dateInitiated, 
                             img_alt, img_path, lastUpdate, 
                             slug, status, title, 
                             relatedTopics[]->{_id, _key, name, slug, type}, type}`;
@@ -93,7 +93,6 @@ function SectionTracker(props) {
   const [allActions, setAllActions] = useState([]);
   const [topics, setTopics] = useState([]);
   const [filters, setFilters] = useState([]);
-  const [loading, setLoading] = useState(true);
 
   const headers = [
     { id: "title", label: "Name" },
@@ -116,7 +115,6 @@ function SectionTracker(props) {
         setActions(allPolicies);
         setAllActions(allPolicies);
       }
-      setLoading(false);
     });
 
     client.fetch(topicsQuery).then((topics) => {

--- a/src/layouts/topic.js
+++ b/src/layouts/topic.js
@@ -136,7 +136,8 @@ const Topic = props => {
             </Grid>
             <Grid container spacing={4} direction="column" item sm={12} md={4}>
               <Grid item>
-                <RelatedGuide {...props} />
+                Guide goes here
+                {/* <RelatedGuide {...props} /> */}
               </Grid>
               <Grid item>
                 <RelatedCommentary commentary={headlines} />

--- a/studio/package-lock.json
+++ b/studio/package-lock.json
@@ -3349,6 +3349,15 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -7870,6 +7879,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "nan": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
+      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
+      "optional": true
     },
     "nano-pubsub": {
       "version": "2.0.1",
@@ -14176,7 +14191,11 @@
           "version": "1.2.13",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",


### PR DESCRIPTION
The PR unfortunately does two things:

1) The tracker section should be working as expected now! Be sure to try out the filters. I think the filter logic could use an update (e.g. if both `European Union` and `antitrust` are clicked, it shows policy actions that have either of those tags, instead of policy actions that have both), but I can open up another issue for that. 

2) Updates to Sanity studio -- it might cause issues with deployment (locally, the `node-modules` in the studio folder need to be destroyed and `npm install` need to be run for the new version to work, I'm guessing something similar might need to be done with the deployed version? Idk though!)