### PR TITLE
Passing filters from the topic page to the search page

### DIFF
--- a/src/components/NextLinkComposed.js
+++ b/src/components/NextLinkComposed.js
@@ -1,0 +1,115 @@
+import * as React from "react";
+import PropTypes from "prop-types";
+import clsx from "clsx";
+import { useRouter } from "next/router";
+import NextLink from "next/link";
+import MuiLink from "@mui/material/Link";
+import { styled } from "@mui/material/styles";
+
+// Add support for the sx prop for consistency with the other branches.
+const Anchor = styled("a")({});
+
+export const NextLinkComposed = React.forwardRef(function NextLinkComposed(
+  props,
+  ref
+) {
+  const {
+    to,
+    linkAs,
+    href,
+    replace,
+    scroll,
+    shallow,
+    prefetch,
+    locale,
+    ...other
+  } = props;
+
+  return (
+    <NextLink
+      href={to}
+      prefetch={prefetch}
+      as={linkAs}
+      replace={replace}
+      scroll={scroll}
+      shallow={shallow}
+      passHref
+      locale={locale}
+    >
+      <Anchor ref={ref} {...other} />
+    </NextLink>
+  );
+});
+
+NextLinkComposed.propTypes = {
+  href: PropTypes.any,
+  linkAs: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
+  locale: PropTypes.string,
+  passHref: PropTypes.bool,
+  prefetch: PropTypes.bool,
+  replace: PropTypes.bool,
+  scroll: PropTypes.bool,
+  shallow: PropTypes.bool,
+  to: PropTypes.oneOfType([PropTypes.object, PropTypes.string]).isRequired,
+};
+
+// A styled version of the Next.js Link component:
+// https://nextjs.org/docs/api-reference/next/link
+const Link = React.forwardRef(function Link(props, ref) {
+  const {
+    activeClassName = "active",
+    as: linkAs,
+    className: classNameProps,
+    href,
+    noLinkStyle,
+    role, // Link don't have roles.
+    ...other
+  } = props;
+
+  const router = useRouter();
+  const pathname = typeof href === "string" ? href : href.pathname;
+  const className = clsx(classNameProps, {
+    [activeClassName]: router.pathname === pathname && activeClassName,
+  });
+
+  const isExternal =
+    typeof href === "string" &&
+    (href.indexOf("http") === 0 || href.indexOf("mailto:") === 0);
+
+  if (isExternal) {
+    if (noLinkStyle) {
+      return <Anchor className={className} href={href} ref={ref} {...other} />;
+    }
+
+    return <MuiLink className={className} href={href} ref={ref} {...other} />;
+  }
+
+  if (noLinkStyle) {
+    return (
+      <NextLinkComposed className={className} ref={ref} to={href} {...other} />
+    );
+  }
+
+  return (
+    <MuiLink
+      component={NextLinkComposed}
+      linkAs={linkAs}
+      className={className}
+      ref={ref}
+      to={href}
+      {...other}
+    />
+  );
+});
+
+Link.propTypes = {
+  activeClassName: PropTypes.string,
+  as: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
+  className: PropTypes.string,
+  href: PropTypes.any,
+  linkAs: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
+  noLinkStyle: PropTypes.bool,
+  role: PropTypes.string,
+};
+
+export default Link;

--- a/src/components/NextLinkComposed.js
+++ b/src/components/NextLinkComposed.js
@@ -13,17 +13,8 @@ export const NextLinkComposed = React.forwardRef(function NextLinkComposed(
   props,
   ref
 ) {
-  const {
-    to,
-    linkAs,
-    href,
-    replace,
-    scroll,
-    shallow,
-    prefetch,
-    locale,
-    ...other
-  } = props;
+  const { to, linkAs, replace, scroll, shallow, prefetch, locale, ...other } =
+    props;
 
   return (
     <NextLink
@@ -62,7 +53,6 @@ const Link = React.forwardRef(function Link(props, ref) {
     className: classNameProps,
     href,
     noLinkStyle,
-    role, // Link don't have roles.
     ...other
   } = props;
 

--- a/src/components/RelatedCommentary.js
+++ b/src/components/RelatedCommentary.js
@@ -37,7 +37,7 @@ const useStyles = makeStyles(() => ({
 }));
 
 const RelatedCommentary = (props) => {
-  const { commentary, topic, type } = props;
+  const { commentary, topic } = props;
   if (!Array.isArray(commentary) || !commentary.length) return null;
   const classes = useStyles();
   const [sortedCommentary, setSortedCommentary] = useState(null);
@@ -75,7 +75,7 @@ const RelatedCommentary = (props) => {
               <Link
                 href={{
                   pathname: "/search",
-                  query: { filter: topic, type: type },
+                  query: { filter: topic },
                 }}
                 className={classes.link}
               >
@@ -124,7 +124,6 @@ const RelatedCommentary = (props) => {
 RelatedCommentary.propTypes = {
   commentary: PropTypes.array,
   topic: PropTypes.string,
-  type: PropTypes.string,
 };
 
 export default RelatedCommentary;

--- a/src/components/RelatedCommentary.js
+++ b/src/components/RelatedCommentary.js
@@ -7,7 +7,7 @@ import moment from "moment-strftime";
 // Material UI imports
 import { makeStyles } from "@mui/styles";
 import Grid from "@mui/material/Grid";
-import Link from "@mui/material/Link";
+import Link from "./NextLinkComposed"
 import Typography from "@mui/material/Typography";
 
 const useStyles = makeStyles(() => ({
@@ -37,7 +37,7 @@ const useStyles = makeStyles(() => ({
 }));
 
 const RelatedCommentary = (props) => {
-  const { commentary } = props;
+  const { commentary, topic, type } = props;
   if (!Array.isArray(commentary) || !commentary.length) return null;
   const classes = useStyles();
   const [sortedCommentary, setSortedCommentary] = useState(null);
@@ -72,7 +72,10 @@ const RelatedCommentary = (props) => {
           </Grid>
           <Grid item xs={4}>
             <Typography component="div" variant="h4">
-              <Link href="/search" className={classes.link}>
+              <Link
+                href={{ pathname: "/search", query: { filter: topic, type: type } }}
+                className={classes.link}
+              >
                 View all
               </Link>
             </Typography>

--- a/src/components/RelatedCommentary.js
+++ b/src/components/RelatedCommentary.js
@@ -7,7 +7,7 @@ import moment from "moment-strftime";
 // Material UI imports
 import { makeStyles } from "@mui/styles";
 import Grid from "@mui/material/Grid";
-import Link from "./NextLinkComposed"
+import Link from "./NextLinkComposed";
 import Typography from "@mui/material/Typography";
 
 const useStyles = makeStyles(() => ({
@@ -73,7 +73,10 @@ const RelatedCommentary = (props) => {
           <Grid item xs={4}>
             <Typography component="div" variant="h4">
               <Link
-                href={{ pathname: "/search", query: { filter: topic, type: type } }}
+                href={{
+                  pathname: "/search",
+                  query: { filter: topic, type: type },
+                }}
                 className={classes.link}
               >
                 View all
@@ -120,6 +123,8 @@ const RelatedCommentary = (props) => {
 
 RelatedCommentary.propTypes = {
   commentary: PropTypes.array,
+  topic: PropTypes.string,
+  type: PropTypes.string,
 };
 
 export default RelatedCommentary;

--- a/src/components/SectionHero.js
+++ b/src/components/SectionHero.js
@@ -111,7 +111,7 @@ function SectionHero(props) {
             </Typography>
           ) : page.__metadata.modelName == "topic" ? (
             <Typography variant="h4" className={classes.superTitle}>
-              {page.type}
+              {page.type === "country" ? "Government" : page.type}
             </Typography>
           ) : page.__metadata.modelName == "article" ? (
             <Typography variant="h4" className={classes.superTitle}>

--- a/src/components/SectionSearch.js
+++ b/src/components/SectionSearch.js
@@ -72,7 +72,6 @@ const SectionSearch = () => {
   const [countries, setCountries] = useState([]);
 
   useEffect(() => {
-    console.log("QUERY in the useEffect", query.filter);
     client.fetch(citationsQuery).then((cites) => {
       if (Array.isArray(cites) && cites.length) {
         setAllCitations(cites);
@@ -104,23 +103,22 @@ const SectionSearch = () => {
       });
     }
 
-    console.log("newTopics", newTopics);
     let newFilters = [];
-    ["issue", "policy", "company", "country"].forEach((type) => {
-      if (Array.isArray(query[type]) && query[type].length) {
-        query[type].forEach((t) => {
-          const exists = newTopics[type].get(t);
-          if (exists) {
-            newFilters.push(exists);
-          }
-        });
-      } else {
-        const exists = newTopics[type].get(query[type]);
-        if (exists) {
-          newFilters.push(exists);
-        }
-      }
-    });
+    // ["issue", "policy", "company", "country"].forEach((type) => {
+    //   if (query[type]) {
+    //     query[type].forEach((t) => {
+    //       const exists = newTopics[type].get(t);
+    //       if (exists) {
+    //         newFilters.push(exists);
+    //       }
+    //     });
+    //   } else {
+    //     const exists = newTopics[type].get(query[type]);
+    //     if (exists) {
+    //       newFilters.push(exists);
+    //     }
+    //   }
+    // });
 
     setIssues(Array.from(newTopics.issue.values()));
     setPolicies(Array.from(newTopics.policy.values()));
@@ -128,11 +126,20 @@ const SectionSearch = () => {
     setCountries(Array.from(newTopics.country.values()));
     newFilters.sort();
     setFilters(newFilters);
+  }, [topics]);
+
+  useEffect(() => {
+    let filterTopic;
+    if (query.filter) {
+      filterTopic = topics.filter((topic) => topic._id === query.filter);
+      setFilters(filterTopic);
+    }
   }, [query, topics]);
 
   useEffect(() => {
     if (allCitations.length) {
       let newCitations = allCitations;
+
       if (filters.length) {
         newCitations = newCitations.filter((citation) => {
           let matches = 0;
@@ -146,8 +153,6 @@ const SectionSearch = () => {
         });
       }
 
-      console.log("FILTERS*******", filters);
-
       if (search) {
         newCitations = newCitations.filter((citation) => {
           const regex = new RegExp(`${search}`, "i");
@@ -160,7 +165,6 @@ const SectionSearch = () => {
           return false;
         });
       }
-      console.log("newCitations", newCitations);
       setCitations(newCitations);
     }
   }, [filters, search, allCitations]);

--- a/src/components/SectionSearch.js
+++ b/src/components/SectionSearch.js
@@ -183,6 +183,9 @@ const SectionSearch = () => {
   };
 
   const handleDelete = (topic) => () => {
+    if (query.filter && history) {
+      history.pushState(null, "", location.href.split("?")[0]);
+    }
     if (topic) {
       setFilters(filters.filter((f) => f.slug !== topic.slug));
     }

--- a/src/components/SectionSearch.js
+++ b/src/components/SectionSearch.js
@@ -21,7 +21,7 @@ import FancyCard from "./FancyCard";
 import SearchBar from "./SearchBar";
 
 const citationsQuery =
-  '*[!(_id in path("drafts.**")) && _type == "citation"]{_id, citation, citationPublication, citationTitle, date, publicationTitle, ref, topics, title, url, websiteTitle} | order(date desc)';
+  '*[!(_id in path("drafts.**")) && _type == "citation"]{_id, citation, citationPublication, citationTitle, date, publicationTitle, ref, topics[]->{_key, _id, name, slug}, title, url, websiteTitle} | order(date desc)';
 
 const topicsQuery =
   '*[!(_id in path("drafts.**")) && _type == "topic"]{_id, name, slug, type}';
@@ -72,6 +72,7 @@ const SectionSearch = () => {
   const [countries, setCountries] = useState([]);
 
   useEffect(() => {
+    console.log("QUERY in the useEffect", query.filter);
     client.fetch(citationsQuery).then((cites) => {
       if (Array.isArray(cites) && cites.length) {
         setAllCitations(cites);
@@ -103,6 +104,7 @@ const SectionSearch = () => {
       });
     }
 
+    console.log("newTopics", newTopics);
     let newFilters = [];
     ["issue", "policy", "company", "country"].forEach((type) => {
       if (Array.isArray(query[type]) && query[type].length) {
@@ -136,13 +138,16 @@ const SectionSearch = () => {
           let matches = 0;
           if (Array.isArray(citation.topics) && citation.topics.length) {
             citation.topics.forEach((topic) => {
-              if (filters.findIndex((f) => f.name === topic.name) >= 0)
+              if (filters.findIndex((f) => f._id === topic._id) >= 0)
                 matches += 1;
             });
           }
           return matches >= filters.length;
         });
       }
+
+      console.log("FILTERS*******", filters);
+
       if (search) {
         newCitations = newCitations.filter((citation) => {
           const regex = new RegExp(`${search}`, "i");
@@ -155,6 +160,7 @@ const SectionSearch = () => {
           return false;
         });
       }
+      console.log("newCitations", newCitations);
       setCitations(newCitations);
     }
   }, [filters, search, allCitations]);

--- a/src/layouts/topic.js
+++ b/src/layouts/topic.js
@@ -154,7 +154,11 @@ const Topic = (props) => {
                 <RelatedGuide {...props} />
               </Grid>
               <Grid item>
-                <RelatedCommentary commentary={headlines} />
+                <RelatedCommentary
+                  commentary={headlines}
+                  topic={page.slug}
+                  type={page.type}
+                />
               </Grid>
               <Grid item>
                 <RelatedTopics title="Related Issues" topics={issues} />

--- a/src/layouts/topic.js
+++ b/src/layouts/topic.js
@@ -154,11 +154,7 @@ const Topic = (props) => {
                 <RelatedGuide {...props} />
               </Grid>
               <Grid item>
-                <RelatedCommentary
-                  commentary={headlines}
-                  topic={page.slug}
-                  type={page.type}
-                />
+                <RelatedCommentary commentary={headlines} topic={page.slug} />
               </Grid>
               <Grid item>
                 <RelatedTopics title="Related Issues" topics={issues} />


### PR DESCRIPTION
Hiya! This PR does two main things:

- [x] Updated the `Link` component that's used in the `RelatedCommentary` to accommodate a filter query parameter, which then filters the citations on the `Search` page. To test, go to any topic page, e.g. http://localhost:3000/policy/privacy, click on the View All link in the `RelatedCommentary` component (next to Latest Headlines and Highlights). The search page should have the filter pre-clicked for privacy.
- [x] A minor fix to the filtering logic in the Search page to address the first issue that Ben brought up in this issue: https://github.com/ResetNetwork/recoding-tech/issues/76#issuecomment-1048120658. 